### PR TITLE
Support Python 2.6

### DIFF
--- a/papery/sitemap.py
+++ b/papery/sitemap.py
@@ -51,8 +51,9 @@ class Sitemap(object):
         with codecs.open(path, 'w', encoding="utf-8") as fp:
             fp.write(content)
 
-        with gzip.open(path + '.gz', 'wb') as gzfp:
-            gzfp.write(content.encode('utf-8'))
+        gzfp = gzip.open(path + '.gz', 'wb')
+        gzfp.write(content.encode('utf-8'))
+        gzfp.close()
 
     @property
     def content(self):

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,10 @@ def find_package_data(where='.', package='',
                 out.setdefault(package, []).append(prefix+name)
     return out
 
+install_requires = ["jinja2", "markdown2"]
+if sys.version_info < (2, 7):
+    install_requires += ["argparse"]
+
 setup(
     name="papery",
     version=version,
@@ -116,7 +120,7 @@ setup(
     author="Xcoo, Inc.",
     author_email="developer@xcoo.jp",
     url="https://github.com/withletters/papery",
-    install_requires=["jinja2", "markdown2"],
+    install_requires=install_requires,
     packages=['papery'],
     package_data=find_package_data('papery',
                                    package='papery',


### PR DESCRIPTION
Supports Python 2.6.

Change:
- Add `argparse` dependency if Python version is under 2.7
- Not use `with` statement for `gzip` because `gzip` in Python 2.6 does not support the Context Manager protocol 
