### PR TITLE
Feature: add code block extension

### DIFF
--- a/papery/data/sample/pages/index.md
+++ b/papery/data/sample/pages/index.md
@@ -8,10 +8,21 @@ Welecome to my web site with [papery](http://github.com/withletters/papery)
 
 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
 Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 
 | Header 1 | *Header* 2 |
 | -------- | -------- |
 | `Cell 1` | [Cell 2](http://example.com) link |
 | Cell 3 | **Cell 4** |
+
+``` text
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+```
+
+``` python
+def factorial(x):
+    if x == 0:
+        return 1
+    else:
+        return x * factorial(x - 1)
+```

--- a/papery/data/sample/themes/default/assets/css/style.css
+++ b/papery/data/sample/themes/default/assets/css/style.css
@@ -1,7 +1,7 @@
 @charset "utf-8";
 
 body {
-    background: #f5f5f5;
+    background: #f0f0f0;
     font-family: Verdana, sans-serif;
     margin: 0;
 }

--- a/papery/page.py
+++ b/papery/page.py
@@ -52,8 +52,11 @@ class Post(object):
         fp.close()
 
         html = markdown.markdown(text,
-                                 extensions=["tables", "pymdownx.emoji"],
+                                 extensions=["tables", "fenced_code", "codehilite", "pymdownx.emoji"],
                                  extension_configs={
+                                     "codehilite": {
+                                         "noclasses": "True"
+                                     },
                                      "pymdownx.emoji": {
                                          "emoji_index": pymdownx.emoji.gemoji,
                                          "emoji_generator": pymdownx.emoji.to_png,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Jinja2>=2.6
 markdown>=3.2
+Pygments>=2.14.0


### PR DESCRIPTION
Fixes #16 
This PR adds code block extension by [`fenced_code`](https://python-markdown.github.io/extensions/fenced_code_blocks/) and [`codehilite`](https://python-markdown.github.io/extensions/code_hilite/#setup).