### PR TITLE
Feat: add skip-validation option for run command

### DIFF
--- a/papery/engine.py
+++ b/papery/engine.py
@@ -68,6 +68,10 @@ class Engine(object):
                                 type=int,
                                 help='output debug log')
 
+        parser_run.add_argument('-s','--skip-validation',
+                                action='store_true',
+                                help='run development server without validation')
+
         parser_init = subparsers.add_parser('init',
                                             help='initialize site')
         parser_init.add_argument('--debug',

--- a/papery/papery.py
+++ b/papery/papery.py
@@ -49,11 +49,12 @@ class Papery(object):
                                              self.themes_dir,
                                              self.files_dir,
                                              self.favicon_dir,
-                                             self.output_dir)
+                                             self.output_dir,
+                                             args['skip_validation'])
         renderer.run()
 
     def run_server(self, **args):
-        self.render()
+        self.render(skip_validation=args['skip_validation'])
 
         watch_dirs = []
 
@@ -66,11 +67,12 @@ class Papery(object):
 
         server = papery.serving.Server(root_dir=self.output_dir,
                                        watch_dirs=watch_dirs,
-                                       change_handler=self.rebuild)
+                                       change_handler=self.rebuild,
+                                       skip_validation=args['skip_validation'])
         server.run()
 
-    def rebuild(self):
-        self.render()
+    def rebuild(self, **args):
+        self.render(skip_validation=args['skip_validation'])
 
     def clean(self, **args):
         renderer = papery.rendering.Renderer(self.config,

--- a/papery/rendering.py
+++ b/papery/rendering.py
@@ -43,7 +43,8 @@ class Renderer(object):
                  themes_dir="themes",
                  files_dir="files",
                  favicon_dir="",
-                 output_dir="output"):
+                 output_dir="output",
+                 skip_validation=False):
         fixed_config = {}
         for k, v in config.items():
             fixed_config[re.sub('-', '_', k)] = v
@@ -53,6 +54,7 @@ class Renderer(object):
         self.themes_dir = themes_dir
         self.files_dir = files_dir
         self.favicon_dir = favicon_dir
+        self.skip_validation = skip_validation
 
         if "theme" not in self.config:
             self.config["theme"] = "default"
@@ -80,7 +82,8 @@ class Renderer(object):
 
     def run(self):
         self._check()
-        self._validate()
+        if not self.skip_validation:
+            self._validate()
         self._prepare_output()
         self._scan()
         self._render_pages()


### PR DESCRIPTION
resolve #29 

Add `--skip-validation` (or `-s`) option for `papery run` command. It enables to skip validation when running or reloading the development server.