### PR TITLE
Fix: markdown extensions

### DIFF
--- a/papery/data/sample/pages/index.md
+++ b/papery/data/sample/pages/index.md
@@ -1,5 +1,7 @@
 # My web site
 
+[toc]
+
 Welecome to my web site with [papery](http://github.com/withletters/papery)
 
 :smile: :heart: :thumbsup:
@@ -35,6 +37,17 @@ def factorial(x):
     else:
         return x * factorial(x - 1)
 ```
+
+### Code block inside the lists
+
+1. You can add
+
+    ``` text
+    Some code block
+    Inside the lists
+    ```
+
+2. And continue indexing...
 
 ## Permalink
 
@@ -91,17 +104,15 @@ h3:hover .headerlink {
 - A *Markdown* text
 - Here is a example with `details` element
 
-``` html
-<details markdown="block">
-<summary> Example </summary>
+    ``` html
+    <details markdown="block">
+    <summary> Example </summary>
 
-#### Example
+    #### Example
 
-Something Markdown text...
-
-</details>
-```
-
+    Some Markdown text...
+    </details>
+    ```
 </details>
 
 ### My Favorite Fruits

--- a/papery/page.py
+++ b/papery/page.py
@@ -58,7 +58,8 @@ class Post(object):
                                              "codehilite",
                                              "pymdownx.emoji",
                                              "md_in_html",
-                                             "toc"],
+                                             "toc",
+                                             "pymdownx.superfences"],
                                  extension_configs={
                                      "codehilite": {
                                          "noclasses": "True"
@@ -71,6 +72,7 @@ class Post(object):
                                              # TODO make "image_path" configurable by papery's configuration file for security reasons
                                          }},
                                      "toc": {
+                                         "marker": "[toc]",
                                          "permalink": "True",
                                          "slugify": markdown.extensions.toc.slugify_unicode
                                      }})


### PR DESCRIPTION
Tweak Markdown extensions about below:

- Add [`pymdownx.superfences`](https://facelessuser.github.io/pymdown-extensions/extensions/superfences/) to enable to add code block inside the list
- Add marker config for table of contents

And update the sample page by using above them.