### PR TITLE
Feat: add skip-validation option for build command

### DIFF
--- a/papery/engine.py
+++ b/papery/engine.py
@@ -62,6 +62,10 @@ class Engine(object):
                                   type=int,
                                   help='output debug log')
 
+        parser_build.add_argument('-s','--skip-validation',
+                                  action='store_true',
+                                  help='build resources without validation')
+
         parser_run = subparsers.add_parser('run',
                                            help='run development server')
         parser_run.add_argument('--debug',


### PR DESCRIPTION
cf. #29 
This PR enables that `skip-validation` option for `papery build` command.