### PR TITLE
The table of contents marker [toc] is specified in lowercase

### DIFF
--- a/papery/page.py
+++ b/papery/page.py
@@ -72,7 +72,7 @@ class Post(object):
                                              # TODO make "image_path" configurable by papery's configuration file for security reasons
                                          }},
                                      "toc": {
-                                         "marker": "[toc]",
+                                         "marker": "[TOC]",
                                          "permalink": "True",
                                          "slugify": markdown.extensions.toc.slugify_unicode
                                      }})

--- a/papery/page.py
+++ b/papery/page.py
@@ -72,7 +72,6 @@ class Post(object):
                                              # TODO make "image_path" configurable by papery's configuration file for security reasons
                                          }},
                                      "toc": {
-                                         "marker": "[TOC]",
                                          "permalink": "True",
                                          "slugify": markdown.extensions.toc.slugify_unicode
                                      }})


### PR DESCRIPTION
cf. #36 

This PR changes `[toc]` to `[TOC]`
The default for [Python-Markdown](https://python-markdown.github.io/reference/markdown/extensions/toc/#markdown.extensions.toc.TocExtension.config) and [HackMD documentation](https://hackmd.io/features#ToC) is `[TOC]` in uppercase letters.